### PR TITLE
Add initial Sequelize models for project management app

### DIFF
--- a/models/Milestone.js
+++ b/models/Milestone.js
@@ -1,0 +1,43 @@
+const { Model, DataTypes } = require('sequelize');
+
+/**
+ * Milestone model represents checkpoints inside a project.
+ */
+module.exports = (sequelize) => {
+  class Milestone extends Model {}
+
+  Milestone.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      projectId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: { model: 'projects', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      description: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      dueDate: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      modelName: 'Milestone',
+      tableName: 'milestones',
+    }
+  );
+
+  return Milestone;
+};

--- a/models/Project.js
+++ b/models/Project.js
@@ -1,0 +1,41 @@
+const { Model, DataTypes } = require('sequelize');
+
+/**
+ * Project model describes a project that groups milestones and tasks.
+ */
+module.exports = (sequelize) => {
+  class Project extends Model {}
+
+  Project.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      description: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      startDate: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+      dueDate: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      modelName: 'Project',
+      tableName: 'projects',
+    }
+  );
+
+  return Project;
+};

--- a/models/Task.js
+++ b/models/Task.js
@@ -1,0 +1,60 @@
+const { Model, DataTypes } = require('sequelize');
+
+/**
+ * Task model represents a unit of work within a project.
+ */
+module.exports = (sequelize) => {
+  class Task extends Model {}
+
+  Task.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      projectId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: { model: 'projects', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      milestoneId: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        references: { model: 'milestones', key: 'id' },
+        onDelete: 'SET NULL',
+      },
+      title: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      description: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+      status: {
+        type: DataTypes.ENUM('todo', 'in_progress', 'done'),
+        allowNull: false,
+        defaultValue: 'todo',
+      },
+      assignedUserId: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'SET NULL',
+      },
+      dueDate: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      modelName: 'Task',
+      tableName: 'tasks',
+    }
+  );
+
+  return Task;
+};

--- a/models/TimeLog.js
+++ b/models/TimeLog.js
@@ -1,0 +1,45 @@
+const { Model, DataTypes } = require('sequelize');
+
+/**
+ * TimeLog model records the time spent by a user on a specific task.
+ */
+module.exports = (sequelize) => {
+  class TimeLog extends Model {}
+
+  TimeLog.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      taskId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: { model: 'tasks', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      hours: {
+        type: DataTypes.DECIMAL,
+        allowNull: false,
+      },
+      date: {
+        type: DataTypes.DATEONLY,
+        allowNull: false,
+      },
+    },
+    {
+      sequelize,
+      modelName: 'TimeLog',
+      tableName: 'time_logs',
+    }
+  );
+
+  return TimeLog;
+};

--- a/models/User.js
+++ b/models/User.js
@@ -1,0 +1,49 @@
+const { Model, DataTypes } = require('sequelize');
+
+/**
+ * User model represents an application user.
+ * Each user can be assigned to many tasks and can log time on tasks.
+ */
+module.exports = (sequelize) => {
+  class User extends Model {}
+
+  User.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true,
+        validate: { isEmail: true },
+      },
+      password: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      role: {
+        type: DataTypes.ENUM('admin', 'user'),
+        allowNull: false,
+        defaultValue: 'user',
+      },
+      hourlyRate: {
+        type: DataTypes.DECIMAL,
+        allowNull: true,
+      },
+    },
+    {
+      sequelize,
+      modelName: 'User',
+      tableName: 'users',
+    }
+  );
+
+  return User;
+};

--- a/models/index.js
+++ b/models/index.js
@@ -1,0 +1,43 @@
+/**
+ * Initializes all models and sets up their associations.
+ * Call this function with a Sequelize instance.
+ */
+const User = require('./User');
+const Project = require('./Project');
+const Milestone = require('./Milestone');
+const Task = require('./Task');
+const TimeLog = require('./TimeLog');
+
+module.exports = (sequelize) => {
+  const models = {
+    User: User(sequelize),
+    Project: Project(sequelize),
+    Milestone: Milestone(sequelize),
+    Task: Task(sequelize),
+    TimeLog: TimeLog(sequelize),
+  };
+
+  // Project relationships
+  models.Project.hasMany(models.Task, { foreignKey: 'projectId', onDelete: 'CASCADE' });
+  models.Task.belongsTo(models.Project, { foreignKey: 'projectId' });
+
+  models.Project.hasMany(models.Milestone, { foreignKey: 'projectId', onDelete: 'CASCADE' });
+  models.Milestone.belongsTo(models.Project, { foreignKey: 'projectId' });
+
+  // Milestone to Task (optional)
+  models.Milestone.hasMany(models.Task, { foreignKey: 'milestoneId', onDelete: 'SET NULL' });
+  models.Task.belongsTo(models.Milestone, { foreignKey: 'milestoneId' });
+
+  // User to Task (assignment)
+  models.User.hasMany(models.Task, { foreignKey: 'assignedUserId', as: 'assignedTasks' });
+  models.Task.belongsTo(models.User, { foreignKey: 'assignedUserId', as: 'assignedUser' });
+
+  // Time logs relationships
+  models.Task.hasMany(models.TimeLog, { foreignKey: 'taskId', onDelete: 'CASCADE' });
+  models.TimeLog.belongsTo(models.Task, { foreignKey: 'taskId' });
+
+  models.User.hasMany(models.TimeLog, { foreignKey: 'userId', onDelete: 'CASCADE' });
+  models.TimeLog.belongsTo(models.User, { foreignKey: 'userId' });
+
+  return models;
+};


### PR DESCRIPTION
## Summary
- define Sequelize models for User, Project, Milestone, Task, and TimeLog
- set up associations linking users, projects, milestones, tasks, and time logs

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a456390fc08330af2594e20d98c1ff