### PR TITLE
Implement JWT auth and role-based access control

### DIFF
--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -1,0 +1,24 @@
+const jwt = require('jsonwebtoken');
+
+/**
+ * Middleware verifying JWT tokens from the Authorization header.
+ * If valid, the decoded user info is attached to req.user.
+ */
+module.exports = (req, res, next) => {
+  const authHeader = req.headers['authorization'];
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'Authorization token missing' });
+  }
+
+  const token = authHeader.split(' ')[1];
+  try {
+    const secret = process.env.JWT_SECRET || 'secret';
+    // Decode and verify the token
+    const decoded = jwt.verify(token, secret);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid or expired token' });
+  }
+};

--- a/middleware/authorizeRole.js
+++ b/middleware/authorizeRole.js
@@ -1,0 +1,10 @@
+/**
+ * Returns a middleware ensuring the user has the required role.
+ * If the user does not meet the requirement, a 403 is returned.
+ */
+module.exports = (role) => (req, res, next) => {
+  if (!req.user || req.user.role !== role) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  next();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "pg-hstore": "^2.3.4",
         "sequelize": "^6.37.7"
@@ -58,6 +60,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -77,6 +93,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -199,6 +221,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -487,10 +518,95 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -578,6 +694,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3",
     "pg-hstore": "^2.3.4",
     "sequelize": "^6.37.7"

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+/**
+ * Routes handling user registration and login.
+ */
+module.exports = (models) => {
+  const router = express.Router();
+  const { User } = models;
+  const secret = process.env.JWT_SECRET || 'secret';
+
+  // POST /auth/register - create a new user with a hashed password
+  router.post('/register', async (req, res) => {
+    try {
+      const { name, email, password } = req.body;
+      const existing = await User.findOne({ where: { email } });
+      if (existing) {
+        return res.status(400).json({ message: 'Email already registered' });
+      }
+      const hash = await bcrypt.hash(password, 10);
+      const user = await User.create({ name, email, password: hash });
+      const { id, role } = user;
+      res.status(201).json({ id, name, email, role });
+    } catch (err) {
+      res.status(400).json({ message: 'Registration failed' });
+    }
+  });
+
+  // POST /auth/login - verify credentials and return a signed JWT
+  router.post('/login', async (req, res) => {
+    try {
+      const { email, password } = req.body;
+      const user = await User.findOne({ where: { email } });
+      if (!user) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const valid = await bcrypt.compare(password, user.password);
+      if (!valid) {
+        return res.status(401).json({ message: 'Invalid credentials' });
+      }
+      const token = jwt.sign({ id: user.id, role: user.role }, secret, {
+        expiresIn: '1h',
+      });
+      const { id, name, role, email: userEmail } = user;
+      res.json({ token, user: { id, name, email: userEmail, role } });
+    } catch (err) {
+      res.status(500).json({ message: 'Login failed' });
+    }
+  });
+
+  return router;
+};

--- a/routes/milestoneRoutes.js
+++ b/routes/milestoneRoutes.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const authorizeRole = require('../middleware/authorizeRole');
 
 module.exports = (models) => {
   const { Milestone } = models;
@@ -16,8 +17,8 @@ module.exports = (models) => {
     }
   });
 
-  // POST /projects/:projectId/milestones - create a milestone for a project
-  projectRouter.post('/', async (req, res) => {
+  // POST /projects/:projectId/milestones - create a milestone for a project (admin only)
+  projectRouter.post('/', authorizeRole('admin'), async (req, res) => {
     try {
       const milestone = await Milestone.create({ ...req.body, projectId: req.params.projectId });
       res.status(201).json(milestone);
@@ -29,8 +30,8 @@ module.exports = (models) => {
   // Router for endpoints under /milestones
   const milestoneRouter = express.Router();
 
-  // PUT /milestones/:id - update a milestone
-  milestoneRouter.put('/:id', async (req, res) => {
+  // PUT /milestones/:id - update a milestone (admin only)
+  milestoneRouter.put('/:id', authorizeRole('admin'), async (req, res) => {
     try {
       const milestone = await Milestone.findByPk(req.params.id);
       if (!milestone) {
@@ -43,8 +44,8 @@ module.exports = (models) => {
     }
   });
 
-  // PATCH /milestones/:id - partially update a milestone
-  milestoneRouter.patch('/:id', async (req, res) => {
+  // PATCH /milestones/:id - partially update a milestone (admin only)
+  milestoneRouter.patch('/:id', authorizeRole('admin'), async (req, res) => {
     try {
       const milestone = await Milestone.findByPk(req.params.id);
       if (!milestone) {
@@ -57,8 +58,8 @@ module.exports = (models) => {
     }
   });
 
-  // DELETE /milestones/:id - remove a milestone
-  milestoneRouter.delete('/:id', async (req, res) => {
+  // DELETE /milestones/:id - remove a milestone (admin only)
+  milestoneRouter.delete('/:id', authorizeRole('admin'), async (req, res) => {
     try {
       const milestone = await Milestone.findByPk(req.params.id);
       if (!milestone) {

--- a/routes/projectRoutes.js
+++ b/routes/projectRoutes.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const authorizeRole = require('../middleware/authorizeRole');
 
 module.exports = (models) => {
   const router = express.Router();
@@ -29,8 +30,8 @@ module.exports = (models) => {
     }
   });
 
-  // POST /projects - create a new project
-  router.post('/', async (req, res) => {
+  // POST /projects - create a new project (admin only)
+  router.post('/', authorizeRole('admin'), async (req, res) => {
     try {
       const project = await Project.create(req.body);
       res.status(201).json(project);
@@ -39,8 +40,8 @@ module.exports = (models) => {
     }
   });
 
-  // PUT /projects/:id - update an existing project
-  router.put('/:id', async (req, res) => {
+  // PUT /projects/:id - update an existing project (admin only)
+  router.put('/:id', authorizeRole('admin'), async (req, res) => {
     try {
       const project = await Project.findByPk(req.params.id);
       if (!project) {
@@ -53,8 +54,8 @@ module.exports = (models) => {
     }
   });
 
-  // PATCH /projects/:id - partially update a project
-  router.patch('/:id', async (req, res) => {
+  // PATCH /projects/:id - partially update a project (admin only)
+  router.patch('/:id', authorizeRole('admin'), async (req, res) => {
     try {
       const project = await Project.findByPk(req.params.id);
       if (!project) {
@@ -67,8 +68,8 @@ module.exports = (models) => {
     }
   });
 
-  // DELETE /projects/:id - remove a project
-  router.delete('/:id', async (req, res) => {
+  // DELETE /projects/:id - remove a project (admin only)
+  router.delete('/:id', authorizeRole('admin'), async (req, res) => {
     try {
       const project = await Project.findByPk(req.params.id);
       if (!project) {
@@ -86,7 +87,12 @@ module.exports = (models) => {
     try {
       const tasks = await Task.findAll({
         where: { projectId: req.params.projectId },
-        include: [{ model: TimeLog, include: [User] }],
+        include: [
+          {
+            model: TimeLog,
+            include: [{ model: User, attributes: { exclude: ['password'] } }],
+          },
+        ],
       });
 
       let totalHours = 0;

--- a/routes/timeLogRoutes.js
+++ b/routes/timeLogRoutes.js
@@ -1,23 +1,43 @@
 const express = require('express');
 
 module.exports = (models) => {
-  const { TimeLog } = models;
+  const { TimeLog, Task } = models;
   const router = express.Router({ mergeParams: true });
 
-  // GET /tasks/:taskId/timelogs - list timelogs for a task
+  // GET /tasks/:taskId/timelogs - list timelogs for a task with access control
   router.get('/', async (req, res) => {
     try {
-      const logs = await TimeLog.findAll({ where: { taskId: req.params.taskId } });
-      res.json(logs);
+      // Admins can view all logs
+      if (req.user.role === 'admin') {
+        const logs = await TimeLog.findAll({ where: { taskId: req.params.taskId } });
+        return res.json(logs);
+      }
+
+      const task = await Task.findByPk(req.params.taskId);
+      if (task && task.assignedUserId === req.user.id) {
+        const logs = await TimeLog.findAll({ where: { taskId: req.params.taskId } });
+        return res.json(logs);
+      }
+
+      // Otherwise, return only logs created by the requesting user
+      const logs = await TimeLog.findAll({
+        where: { taskId: req.params.taskId, userId: req.user.id },
+      });
+      return res.json(logs);
     } catch (err) {
-      res.status(500).json({ error: 'Failed to fetch time logs' });
+      return res.status(500).json({ error: 'Failed to fetch time logs' });
     }
   });
 
   // POST /tasks/:taskId/timelogs - create a timelog for a task
   router.post('/', async (req, res) => {
     try {
-      const log = await TimeLog.create({ ...req.body, taskId: req.params.taskId });
+      const payload = { ...req.body, taskId: req.params.taskId };
+      // Standard users can only log time for themselves
+      if (req.user.role === 'user') {
+        payload.userId = req.user.id;
+      }
+      const log = await TimeLog.create(payload);
       res.status(201).json(log);
     } catch (err) {
       res.status(400).json({ error: 'Failed to create time log' });

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { Sequelize } = require('sequelize');
 const initModels = require('./models');
+const authMiddleware = require('./middleware/authMiddleware');
 
 // Create Express application
 const app = express();
@@ -32,12 +33,20 @@ sequelize
   .then(() => console.log('Database synchronized'))
   .catch((err) => console.error('Database synchronization failed:', err));
 
-// Import and mount routers
+// Import routers
+const authRoutes = require('./routes/authRoutes')(models);
 const projectRoutes = require('./routes/projectRoutes')(models);
 const taskRoutes = require('./routes/taskRoutes')(models);
 const milestoneRoutes = require('./routes/milestoneRoutes')(models);
 const timeLogRoutes = require('./routes/timeLogRoutes')(models);
 
+// Public authentication routes
+app.use('/auth', authRoutes);
+
+// Apply authentication middleware to all routes below
+app.use(authMiddleware);
+
+// Protected resource routes
 app.use('/projects', projectRoutes);
 app.use('/projects/:projectId/tasks', taskRoutes.projectRouter);
 app.use('/tasks', taskRoutes.taskRouter);


### PR DESCRIPTION
## Summary
- add auth routes for registration and login with JWT tokens
- secure API with authentication middleware and role-based authorization
- enforce permissions on project, task, milestone, and timelog endpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4594a83b08330adc6b6b44e189ad0