### PR TITLE
feat: add React front-end

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "project-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "scripts": {
+    "start": "echo \"start script not configured\"",
+    "build": "echo \"build script not configured\"",
+    "test": "echo \"No tests specified\""
+  }
+}

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Project Manager</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { useAuth } from './context/AuthContext';
+import Navbar from './components/Navbar';
+import LoginPage from './pages/LoginPage';
+import RegisterPage from './pages/RegisterPage';
+import ProjectListPage from './pages/ProjectListPage';
+import ProjectDetailPage from './pages/ProjectDetailPage';
+
+// Component protecting routes from unauthenticated access
+const RequireAuth = ({ children }) => {
+  const { token } = useAuth();
+  return token ? children : <Navigate to="/login" replace />;
+};
+
+// Root component configuring routes
+const App = () => {
+  const { token } = useAuth();
+
+  return (
+    <div>
+      {token && <Navbar />}
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
+        <Route
+          path="/projects"
+          element={
+            <RequireAuth>
+              <ProjectListPage />
+            </RequireAuth>
+          }
+        />
+        <Route
+          path="/projects/:id"
+          element={
+            <RequireAuth>
+              <ProjectDetailPage />
+            </RequireAuth>
+          }
+        />
+        <Route path="*" element={<Navigate to="/projects" replace />} />
+      </Routes>
+    </div>
+  );
+};
+
+export default App;

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+// Simple navigation bar displayed when the user is logged in
+const Navbar = () => {
+  const { user, logout } = useAuth();
+  const navigate = useNavigate();
+
+  // Handle logout and redirect to login page
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <nav style={{ padding: '1rem', borderBottom: '1px solid #ccc' }}>
+      <Link to="/projects" style={{ marginRight: '1rem' }}>
+        Projects
+      </Link>
+      <span style={{ marginRight: '1rem' }}>Hello, {user?.name}</span>
+      <button onClick={handleLogout}>Logout</button>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/client/src/components/NewProjectForm.jsx
+++ b/client/src/components/NewProjectForm.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+// Form allowing an admin to create a new project
+const NewProjectForm = ({ onCreated }) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const { token } = useAuth();
+
+  // Submit new project to backend
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('/projects', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ name, description }),
+      });
+      if (res.ok) {
+        setName('');
+        setDescription('');
+        onCreated();
+      }
+    } catch (err) {
+      console.error('Failed to create project', err);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>
+      <h3>New Project</h3>
+      <input
+        type="text"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <br />
+      <textarea
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <br />
+      <button type="submit">Create</button>
+    </form>
+  );
+};
+
+export default NewProjectForm;

--- a/client/src/components/NewTaskForm.jsx
+++ b/client/src/components/NewTaskForm.jsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+// Form allowing an admin to create a new task for a project
+const NewTaskForm = ({ projectId, onCreated }) => {
+  const [title, setTitle] = useState('');
+  const [assignedUserId, setAssignedUserId] = useState('');
+  const { token } = useAuth();
+
+  // Submit new task to backend
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/projects/${projectId}/tasks`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ title, assignedUserId }),
+      });
+      if (res.ok) {
+        setTitle('');
+        setAssignedUserId('');
+        onCreated();
+      }
+    } catch (err) {
+      console.error('Failed to create task', err);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ marginTop: '1rem' }}>
+      <h4>New Task</h4>
+      <input
+        type="text"
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <br />
+      <input
+        type="text"
+        placeholder="Assigned User ID"
+        value={assignedUserId}
+        onChange={(e) => setAssignedUserId(e.target.value)}
+      />
+      <br />
+      <button type="submit">Add Task</button>
+    </form>
+  );
+};
+
+export default NewTaskForm;

--- a/client/src/components/TaskItem.jsx
+++ b/client/src/components/TaskItem.jsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+// Component displaying a single task with controls for status and time logging
+const TaskItem = ({ task, onStatusChange, onTimeLogged }) => {
+  const { token, user } = useAuth();
+  const [hours, setHours] = useState('');
+
+  const canUpdate = user && (user.role === 'admin' || user.id === task.assignedUserId);
+
+  // Mark the task as done
+  const markDone = async () => {
+    try {
+      const res = await fetch(`/tasks/${task.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ status: 'done' }),
+      });
+      if (res.ok) {
+        onStatusChange();
+      }
+    } catch (err) {
+      console.error('Failed to update task', err);
+    }
+  };
+
+  // Log time for the task
+  const logTime = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/tasks/${task.id}/timelogs`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ hours: parseFloat(hours) }),
+      });
+      if (res.ok) {
+        setHours('');
+        onTimeLogged();
+      }
+    } catch (err) {
+      console.error('Failed to log time', err);
+    }
+  };
+
+  return (
+    <li style={{ marginBottom: '0.5rem' }}>
+      <strong>{task.title}</strong> - {task.status} - Assigned to {task.assignedUser?.name}
+      {canUpdate && task.status !== 'done' && (
+        <button onClick={markDone} style={{ marginLeft: '0.5rem' }}>
+          Mark done
+        </button>
+      )}
+      {canUpdate && (
+        <form onSubmit={logTime} style={{ display: 'inline', marginLeft: '0.5rem' }}>
+          <input
+            type="number"
+            step="0.1"
+            placeholder="hours"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            style={{ width: '60px' }}
+          />
+          <button type="submit">Log time</button>
+        </form>
+      )}
+    </li>
+  );
+};
+
+export default TaskItem;

--- a/client/src/context/AuthContext.js
+++ b/client/src/context/AuthContext.js
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState } from 'react';
+
+// Context to share authentication state across the app
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('user');
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  // Perform login by storing token and user information
+  const login = (tokenValue, userInfo) => {
+    setToken(tokenValue);
+    setUser(userInfo);
+    localStorage.setItem('token', tokenValue);
+    localStorage.setItem('user', JSON.stringify(userInfo));
+  };
+
+  // Clear auth data on logout
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// Convenience hook to use auth context
+export const useAuth = () => useContext(AuthContext);

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { AuthProvider } from './context/AuthContext';
+
+// Entry point for React application
+const rootElement = document.getElementById('root');
+const root = createRoot(rootElement);
+
+root.render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+// Page containing login form
+const LoginPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  // Handle login submission
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch('/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        setError('Invalid credentials');
+        return;
+      }
+      const data = await res.json();
+      login(data.token, data.user);
+      navigate('/projects');
+    } catch (err) {
+      setError('Network error');
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Login</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <br />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <br />
+        <button type="submit">Login</button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/client/src/pages/ProjectDetailPage.jsx
+++ b/client/src/pages/ProjectDetailPage.jsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import TaskItem from '../components/TaskItem';
+import NewTaskForm from '../components/NewTaskForm';
+
+// Page displaying details for a single project including tasks and milestones
+const ProjectDetailPage = () => {
+  const { id } = useParams();
+  const { token, user } = useAuth();
+  const [project, setProject] = useState(null);
+  const [cost, setCost] = useState(null);
+
+  // Fetch project details from API
+  const fetchProject = async () => {
+    try {
+      const res = await fetch(`/projects/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setProject(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch project', err);
+    }
+  };
+
+  // Fetch project cost (total hours and cost)
+  const fetchCost = async () => {
+    try {
+      const res = await fetch(`/projects/${id}/cost`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setCost(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch cost', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchProject();
+    fetchCost();
+  }, [id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!project) return <div>Loading...</div>;
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>{project.name}</h2>
+      <p>{project.description}</p>
+      {cost && (
+        <p>
+          Total hours: {cost.totalHours}h, Total cost: {cost.totalCost}€
+        </p>
+      )}
+
+      <h3>Tasks</h3>
+      <ul>
+        {project.tasks?.map((t) => (
+          <TaskItem
+            key={t.id}
+            task={t}
+            onStatusChange={fetchProject}
+            onTimeLogged={fetchCost}
+          />
+        ))}
+      </ul>
+      {user?.role === 'admin' && (
+        <NewTaskForm projectId={id} onCreated={() => { fetchProject(); fetchCost(); }} />
+      )}
+
+      {project.milestones?.length > 0 && (
+        <div>
+          <h3>Milestones</h3>
+          <ul>
+            {project.milestones.map((m) => (
+              <li key={m.id}>
+                {m.title} - {m.dueDate}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProjectDetailPage;

--- a/client/src/pages/ProjectListPage.jsx
+++ b/client/src/pages/ProjectListPage.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import NewProjectForm from '../components/NewProjectForm';
+
+// Page listing all projects for the logged in user
+const ProjectListPage = () => {
+  const [projects, setProjects] = useState([]);
+  const { token, user } = useAuth();
+
+  // Fetch projects from API
+  const fetchProjects = async () => {
+    try {
+      const res = await fetch('/projects', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setProjects(data);
+      }
+    } catch (err) {
+      console.error('Failed to fetch projects', err);
+    }
+  };
+
+  useEffect(() => {
+    fetchProjects();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2>Projects</h2>
+      <ul>
+        {projects.map((p) => (
+          <li key={p.id}>
+            <Link to={`/projects/${p.id}`}>{p.name}</Link>
+          </li>
+        ))}
+      </ul>
+      {user?.role === 'admin' && <NewProjectForm onCreated={fetchProjects} />}
+    </div>
+  );
+};
+
+export default ProjectListPage;

--- a/client/src/pages/RegisterPage.jsx
+++ b/client/src/pages/RegisterPage.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+// Page allowing a new user to register
+const RegisterPage = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  // Handle registration
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await fetch('/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, password }),
+      });
+      if (res.ok) {
+        navigate('/login');
+      } else {
+        setError('Registration failed');
+      }
+    } catch (err) {
+      setError('Network error');
+    }
+  };
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h2>Register</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <br />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <br />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <br />
+        <button type="submit">Register</button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+};
+
+export default RegisterPage;


### PR DESCRIPTION
## Summary
- add React client with authentication context and protected routing
- allow users to login and browse projects
- support viewing project details, manage tasks, and log time

## Testing
- `npm test`
- `cd client && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a45b6d80d08330aab526aaa1153e1f