### PR TITLE
feat: define sequelize models and associations

### DIFF
--- a/backend/src/config/db.js
+++ b/backend/src/config/db.js
@@ -2,9 +2,14 @@
 const { Sequelize } = require('sequelize');
 
 // Use the DATABASE_URL from environment variables
+// Global model settings: timestamps enabled, no underscored field names
 const sequelize = new Sequelize(process.env.DATABASE_URL, {
   dialect: 'postgres',
-  logging: false
+  logging: false,
+  define: {
+    underscored: false,
+    timestamps: true,
+  },
 });
 
 module.exports = { sequelize };

--- a/backend/src/models/Milestone.js
+++ b/backend/src/models/Milestone.js
@@ -1,16 +1,36 @@
 // Milestone model definition
+// Represents key checkpoints within a project
 const { DataTypes } = require('sequelize');
-const { sequelize } = require('../config/db');
-const Project = require('./Project');
 
-const Milestone = sequelize.define('Milestone', {
-  title: { type: DataTypes.STRING, allowNull: false },
-  description: { type: DataTypes.TEXT },
-  dueDate: { type: DataTypes.DATE }
-});
+module.exports = (sequelize) => {
+  const Milestone = sequelize.define('Milestone', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    projectId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment: 'References the owning project',
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    dueDate: {
+      type: DataTypes.DATEONLY,
+      allowNull: true,
+    },
+  }, {
+    indexes: [
+      { fields: ['projectId'] },
+    ],
+  });
 
-// Relationships
-Project.hasMany(Milestone, { foreignKey: 'projectId' });
-Milestone.belongsTo(Project, { foreignKey: 'projectId' });
-
-module.exports = Milestone;
+  return Milestone;
+};

--- a/backend/src/models/Project.js
+++ b/backend/src/models/Project.js
@@ -1,12 +1,31 @@
 // Project model definition
+// Represents a project container for tasks and milestones
 const { DataTypes } = require('sequelize');
-const { sequelize } = require('../config/db');
 
-const Project = sequelize.define('Project', {
-  name: { type: DataTypes.STRING, allowNull: false },
-  description: { type: DataTypes.TEXT },
-  startDate: { type: DataTypes.DATE },
-  dueDate: { type: DataTypes.DATE }
-});
+module.exports = (sequelize) => {
+  const Project = sequelize.define('Project', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    startDate: {
+      type: DataTypes.DATEONLY,
+      allowNull: true,
+    },
+    dueDate: {
+      type: DataTypes.DATEONLY,
+      allowNull: true,
+    },
+  });
 
-module.exports = Project;
+  return Project;
+};

--- a/backend/src/models/Task.js
+++ b/backend/src/models/Task.js
@@ -1,23 +1,53 @@
 // Task model definition
+// Represents an actionable item within a project or milestone
 const { DataTypes } = require('sequelize');
-const { sequelize } = require('../config/db');
-const Project = require('./Project');
-const Milestone = require('./Milestone');
-const User = require('./User');
 
-const Task = sequelize.define('Task', {
-  title: { type: DataTypes.STRING, allowNull: false },
-  description: { type: DataTypes.TEXT },
-  status: { type: DataTypes.STRING, defaultValue: 'pending' },
-  dueDate: { type: DataTypes.DATE }
-});
+module.exports = (sequelize) => {
+  const Task = sequelize.define('Task', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    projectId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment: 'References the owning project',
+    },
+    milestoneId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      comment: 'Optional link to a milestone',
+    },
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    status: {
+      type: DataTypes.ENUM('todo', 'in_progress', 'done'),
+      allowNull: false,
+      defaultValue: 'todo',
+    },
+    assignedUserId: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      comment: 'User assigned to this task',
+    },
+    dueDate: {
+      type: DataTypes.DATEONLY,
+      allowNull: true,
+    },
+  }, {
+    indexes: [
+      { fields: ['projectId'] },
+      { fields: ['milestoneId'] },
+      { fields: ['assignedUserId'] },
+    ],
+  });
 
-// Relationships
-Project.hasMany(Task, { foreignKey: 'projectId' });
-Task.belongsTo(Project, { foreignKey: 'projectId' });
-Milestone.hasMany(Task, { foreignKey: 'milestoneId' });
-Task.belongsTo(Milestone, { foreignKey: 'milestoneId' });
-User.hasMany(Task, { foreignKey: 'assignedUserId' });
-Task.belongsTo(User, { as: 'assignedUser', foreignKey: 'assignedUserId' });
-
-module.exports = Task;
+  return Task;
+};

--- a/backend/src/models/TimeLog.js
+++ b/backend/src/models/TimeLog.js
@@ -1,18 +1,38 @@
 // TimeLog model definition
+// Stores time tracking entries for tasks and users
 const { DataTypes } = require('sequelize');
-const { sequelize } = require('../config/db');
-const Task = require('./Task');
-const User = require('./User');
 
-const TimeLog = sequelize.define('TimeLog', {
-  hours: { type: DataTypes.FLOAT, allowNull: false },
-  date: { type: DataTypes.DATEONLY, allowNull: false }
-});
+module.exports = (sequelize) => {
+  const TimeLog = sequelize.define('TimeLog', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    taskId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment: 'Task being worked on',
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment: 'User who logged the time',
+    },
+    hours: {
+      type: DataTypes.DECIMAL(5, 2),
+      allowNull: false,
+    },
+    date: {
+      type: DataTypes.DATEONLY,
+      allowNull: false,
+    },
+  }, {
+    indexes: [
+      { fields: ['taskId'] },
+      { fields: ['userId'] },
+    ],
+  });
 
-// Relationships
-Task.hasMany(TimeLog, { foreignKey: 'taskId' });
-TimeLog.belongsTo(Task, { foreignKey: 'taskId' });
-User.hasMany(TimeLog, { foreignKey: 'userId' });
-TimeLog.belongsTo(User, { foreignKey: 'userId' });
-
-module.exports = TimeLog;
+  return TimeLog;
+};

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,13 +1,43 @@
 // User model definition
+// Defines application users and roles
 const { DataTypes } = require('sequelize');
-const { sequelize } = require('../config/db');
 
-const User = sequelize.define('User', {
-  name: { type: DataTypes.STRING, allowNull: false },
-  email: { type: DataTypes.STRING, allowNull: false, unique: true },
-  password: { type: DataTypes.STRING, allowNull: false },
-  role: { type: DataTypes.ENUM('admin', 'user'), defaultValue: 'user' },
-  hourlyRate: { type: DataTypes.FLOAT }
-});
+module.exports = (sequelize) => {
+  const User = sequelize.define('User', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: { isEmail: true },
+    },
+    password: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment: 'Hashed user password',
+    },
+    role: {
+      type: DataTypes.ENUM('admin', 'user'),
+      allowNull: false,
+      defaultValue: 'user',
+    },
+    hourlyRate: {
+      type: DataTypes.DECIMAL(10, 2),
+      allowNull: true,
+    },
+  }, {
+    indexes: [
+      { unique: true, fields: ['email'] },
+    ],
+  });
 
-module.exports = User;
+  return User;
+};

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -1,0 +1,100 @@
+// Sequelize model loader and associations
+// Initializes all models and their relationships
+const { sequelize } = require('../config/db');
+const UserModel = require('./User');
+const ProjectModel = require('./Project');
+const MilestoneModel = require('./Milestone');
+const TaskModel = require('./Task');
+const TimeLogModel = require('./TimeLog');
+
+// Instantiate models
+const User = UserModel(sequelize);
+const Project = ProjectModel(sequelize);
+const Milestone = MilestoneModel(sequelize);
+const Task = TaskModel(sequelize);
+const TimeLog = TimeLogModel(sequelize);
+
+/**
+ * Set up model associations.
+ */
+function initModels() {
+  // Project → Task
+  Project.hasMany(Task, {
+    foreignKey: { name: 'projectId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+  Task.belongsTo(Project, {
+    foreignKey: { name: 'projectId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+
+  // Project → Milestone
+  Project.hasMany(Milestone, {
+    foreignKey: { name: 'projectId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+  Milestone.belongsTo(Project, {
+    foreignKey: { name: 'projectId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+
+  // Milestone → Task (optional relationship)
+  Milestone.hasMany(Task, {
+    foreignKey: { name: 'milestoneId', allowNull: true },
+    onDelete: 'SET NULL',
+  });
+  Task.belongsTo(Milestone, {
+    foreignKey: { name: 'milestoneId', allowNull: true },
+    onDelete: 'SET NULL',
+  });
+
+  // User ↔ Task (assigned user)
+  User.hasMany(Task, {
+    foreignKey: { name: 'assignedUserId', allowNull: true },
+    onDelete: 'SET NULL',
+  });
+  Task.belongsTo(User, {
+    as: 'assignedUser',
+    foreignKey: { name: 'assignedUserId', allowNull: true },
+    onDelete: 'SET NULL',
+  });
+
+  // Task → TimeLog
+  Task.hasMany(TimeLog, {
+    foreignKey: { name: 'taskId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+  TimeLog.belongsTo(Task, {
+    foreignKey: { name: 'taskId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+
+  // User → TimeLog
+  User.hasMany(TimeLog, {
+    foreignKey: { name: 'userId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+  TimeLog.belongsTo(User, {
+    foreignKey: { name: 'userId', allowNull: false },
+    onDelete: 'CASCADE',
+  });
+}
+
+/**
+ * Synchronize all models with the database.
+ * @returns {Promise<void>} resolves when sync is complete
+ */
+async function syncDb() {
+  await sequelize.sync();
+}
+
+module.exports = {
+  sequelize,
+  User,
+  Project,
+  Milestone,
+  Task,
+  TimeLog,
+  initModels,
+  syncDb,
+};

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,13 +2,16 @@
 require('dotenv').config();
 const app = require('./app');
 const { sequelize } = require('./config/db');
+const { initModels, syncDb } = require('./models');
 
 const PORT = process.env.PORT || 3000;
 
 async function start() {
   try {
     await sequelize.authenticate();
-    console.log('Database connected');
+    initModels();
+    await syncDb();
+    console.log('Database connected and synced');
     app.listen(PORT, () => {
       console.log(`Server running on port ${PORT}`);
     });


### PR DESCRIPTION
## Summary
- implement User, Project, Milestone, Task and TimeLog models with proper fields
- centralize associations and sync helper
- configure Sequelize defaults and sync on server startup

## Testing
- `npm run lint`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/projectdb node -e "const { initModels, syncDb } = require('./src/models'); initModels(); syncDb().then(()=>{console.log('synced');})"`


------
https://chatgpt.com/codex/tasks/task_e_68a462e39f708330b9b0af164245ac01