### PR TITLE
Add JWT authentication and role-based authorization

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,10 +2,12 @@
 const express = require('express');
 const cors = require('cors');
 
+const authRoutes = require('./routes/auth');
 const projectRoutes = require('./routes/projects');
 const taskRoutes = require('./routes/tasks');
 const milestoneRoutes = require('./routes/milestones');
 const timeLogRoutes = require('./routes/timelogs');
+const authMiddleware = require('./middleware/auth');
 
 const app = express();
 
@@ -14,6 +16,12 @@ app.use(cors());
 
 // Parse incoming JSON bodies
 app.use(express.json());
+
+// Public auth routes
+app.use('/auth', authRoutes);
+
+// Apply authentication to all routes below
+app.use(authMiddleware);
 
 // Register API routes
 app.use('/projects', projectRoutes);
@@ -29,4 +37,3 @@ app.use((err, req, res, _next) => {
 });
 
 module.exports = app;
-

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,63 @@
+// Controller for authentication operations
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const { User } = require('../models');
+
+/**
+ * Register a new user.
+ * Password is hashed before storage and role defaults to 'user'.
+ * Returns a safe user profile without the password.
+ */
+exports.register = async (req, res) => {
+  try {
+    const { name, email, password } = req.body;
+    if (!name || !email || !password) {
+      return res.status(400).json({ message: 'name, email and password are required' });
+    }
+    const existing = await User.findOne({ where: { email } });
+    if (existing) {
+      return res.status(400).json({ message: 'Email already registered' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = await User.create({ name, email, password: hashed, role: 'user' });
+    const safeUser = { id: user.id, name: user.name, email: user.email, role: user.role };
+    return res.status(201).json(safeUser);
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Failed to register user' });
+  }
+};
+
+/**
+ * Authenticate a user and issue a JWT token.
+ * The token contains the user id and role.
+ */
+exports.login = async (req, res) => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ message: 'email and password are required' });
+    }
+    const user = await User.findOne({ where: { email } });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      // Fail closed if no secret is configured
+      return res.status(500).json({ message: 'JWT secret not configured' });
+    }
+    const token = jwt.sign({ id: user.id, role: user.role }, secret, { expiresIn: '1h' });
+    return res.json({
+      token,
+      user: { id: user.id, name: user.name, email: user.email, role: user.role },
+    });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: 'Failed to login' });
+  }
+};

--- a/backend/src/controllers/taskController.js
+++ b/backend/src/controllers/taskController.js
@@ -59,6 +59,19 @@ exports.updateTask = async (req, res) => {
     if (!task) {
       return res.status(404).json({ message: 'Task not found' });
     }
+    if (req.user.role !== 'admin') {
+      // Non-admins may only update status on their own tasks
+      if (task.assignedUserId !== req.user.id) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      const { status } = req.body;
+      if (status === undefined) {
+        return res.status(400).json({ message: 'Status is required' });
+      }
+      await task.update({ status });
+      return res.json(task);
+    }
+    // Admins can update any field
     const { title, description, status, milestoneId, assignedUserId, dueDate } = req.body;
     const updates = {};
     if (title !== undefined) updates.title = title;

--- a/backend/src/controllers/timeLogController.js
+++ b/backend/src/controllers/timeLogController.js
@@ -11,6 +11,21 @@ exports.listTimeLogs = async (req, res) => {
     if (!task) {
       return res.status(404).json({ message: 'Task not found' });
     }
+    if (req.user.role !== 'admin') {
+      // Non-admins may view logs only for tasks they own or are assigned to
+      const isAssigned = task.assignedUserId === req.user.id;
+      const isOwner = await TimeLog.count({ where: { taskId, userId: req.user.id } });
+      if (!isAssigned && isOwner === 0) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      const where = { taskId };
+      if (!isAssigned) {
+        // Not assigned, so restrict to own logs
+        where.userId = req.user.id;
+      }
+      const logs = await TimeLog.findAll({ where });
+      return res.json(logs);
+    }
     const logs = await TimeLog.findAll({ where: { taskId } });
     return res.json(logs);
   } catch (err) {
@@ -29,11 +44,21 @@ exports.createTimeLog = async (req, res) => {
     if (!task) {
       return res.status(404).json({ message: 'Task not found' });
     }
-    const { userId, hours, date } = req.body;
-    if (!userId || !hours || !date) {
-      return res.status(400).json({ message: 'userId, hours and date are required' });
+    const { hours, date } = req.body;
+    if (!hours || !date) {
+      return res.status(400).json({ message: 'hours and date are required' });
     }
-    // Optional: verify user exists
+    let userId = req.body.userId;
+    if (req.user.role !== 'admin') {
+      // Non-admins can only log time for tasks assigned to them
+      if (task.assignedUserId !== req.user.id) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+      userId = req.user.id; // enforce ownership of timelog
+    }
+    if (!userId) {
+      return res.status(400).json({ message: 'userId is required' });
+    }
     const user = await User.findByPk(userId);
     if (!user) {
       return res.status(404).json({ message: 'User not found' });

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,4 +1,4 @@
-// Middleware to verify JWT tokens
+// Middleware to verify JWT tokens and attach user info
 const jwt = require('jsonwebtoken');
 
 module.exports = (req, res, next) => {
@@ -7,9 +7,15 @@ module.exports = (req, res, next) => {
     return res.status(401).json({ message: 'No token provided' });
   }
   const token = authHeader.split(' ')[1];
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    // Reject requests when the secret is missing for security
+    return res.status(401).json({ message: 'Invalid token' });
+  }
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = decoded;
+    const decoded = jwt.verify(token, secret);
+    // Only expose id and role to downstream handlers
+    req.user = { id: decoded.id, role: decoded.role };
     next();
   } catch (err) {
     return res.status(401).json({ message: 'Invalid token' });

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,17 +1,12 @@
 // Authentication routes
 const express = require('express');
 const router = express.Router();
+const authController = require('../controllers/authController');
 
-// POST /auth/register
-router.post('/register', (req, res) => {
-  // TODO: implement user registration
-  res.json({ message: 'Register endpoint' });
-});
+// POST /auth/register -> create a new user
+router.post('/register', authController.register);
 
-// POST /auth/login
-router.post('/login', (req, res) => {
-  // TODO: implement user login
-  res.json({ message: 'Login endpoint' });
-});
+// POST /auth/login -> login and receive JWT token
+router.post('/login', authController.login);
 
 module.exports = router;

--- a/backend/src/routes/milestones.js
+++ b/backend/src/routes/milestones.js
@@ -2,18 +2,18 @@
 const express = require('express');
 const router = express.Router();
 const milestoneController = require('../controllers/milestoneController');
+const authorizeRole = require('../middleware/authorizeRole');
 
 // GET /projects/:projectId/milestones -> list milestones for a project
 router.get('/projects/:projectId/milestones', milestoneController.listMilestones);
 
-// POST /projects/:projectId/milestones -> create milestone for a project
-router.post('/projects/:projectId/milestones', milestoneController.createMilestone);
+// POST /projects/:projectId/milestones -> create milestone for a project (admin only)
+router.post('/projects/:projectId/milestones', authorizeRole('admin'), milestoneController.createMilestone);
 
-// PATCH /milestones/:id -> update a milestone
-router.patch('/milestones/:id', milestoneController.updateMilestone);
+// PATCH /milestones/:id -> update a milestone (admin only)
+router.patch('/milestones/:id', authorizeRole('admin'), milestoneController.updateMilestone);
 
-// DELETE /milestones/:id -> remove a milestone
-router.delete('/milestones/:id', milestoneController.deleteMilestone);
+// DELETE /milestones/:id -> remove a milestone (admin only)
+router.delete('/milestones/:id', authorizeRole('admin'), milestoneController.deleteMilestone);
 
 module.exports = router;
-

--- a/backend/src/routes/projects.js
+++ b/backend/src/routes/projects.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const projectController = require('../controllers/projectController');
+const authorizeRole = require('../middleware/authorizeRole');
 
 // GET /projects -> list all projects
 router.get('/', projectController.listProjects);
@@ -9,17 +10,16 @@ router.get('/', projectController.listProjects);
 // GET /projects/:id -> get project with tasks and milestones
 router.get('/:id', projectController.getProject);
 
-// POST /projects -> create project
-router.post('/', projectController.createProject);
+// POST /projects -> create project (admin only)
+router.post('/', authorizeRole('admin'), projectController.createProject);
 
-// PATCH /projects/:id -> update project
-router.patch('/:id', projectController.updateProject);
+// PATCH /projects/:id -> update project (admin only)
+router.patch('/:id', authorizeRole('admin'), projectController.updateProject);
 
-// DELETE /projects/:id -> delete project
-router.delete('/:id', projectController.deleteProject);
+// DELETE /projects/:id -> delete project (admin only)
+router.delete('/:id', authorizeRole('admin'), projectController.deleteProject);
 
 // GET /projects/:projectId/cost -> compute total hours and cost
 router.get('/:projectId/cost', projectController.getProjectCost);
 
 module.exports = router;
-

--- a/backend/src/routes/tasks.js
+++ b/backend/src/routes/tasks.js
@@ -2,18 +2,18 @@
 const express = require('express');
 const router = express.Router();
 const taskController = require('../controllers/taskController');
+const authorizeRole = require('../middleware/authorizeRole');
 
 // GET /projects/:projectId/tasks -> list tasks for a project
 router.get('/projects/:projectId/tasks', taskController.listTasks);
 
-// POST /projects/:projectId/tasks -> create task for a project
-router.post('/projects/:projectId/tasks', taskController.createTask);
+// POST /projects/:projectId/tasks -> create task for a project (admin only)
+router.post('/projects/:projectId/tasks', authorizeRole('admin'), taskController.createTask);
 
 // PATCH /tasks/:id -> update a task
 router.patch('/tasks/:id', taskController.updateTask);
 
-// DELETE /tasks/:id -> remove a task
-router.delete('/tasks/:id', taskController.deleteTask);
+// DELETE /tasks/:id -> remove a task (admin only)
+router.delete('/tasks/:id', authorizeRole('admin'), taskController.deleteTask);
 
 module.exports = router;
-


### PR DESCRIPTION
## Summary
- implement user registration and login with hashed passwords and JWT issuance
- protect routes with auth middleware and role checks for admin actions
- enforce task and time log permissions based on user role and assignment

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a467caab588330a6d432ca0a094736