### PR TITLE
Add minimal React frontend with JWT auth

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build"
+    "build": "react-scripts build",
+    "test": "react-scripts test"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,15 +4,33 @@ import LoginPage from './pages/LoginPage';
 import ProjectListPage from './pages/ProjectListPage';
 import ProjectDetailPage from './pages/ProjectDetailPage';
 import { AuthProvider } from './context/AuthContext';
+import Navbar from './components/Navbar';
+import RequireAuth from './components/RequireAuth';
 
+// Main application component with routing
 function App() {
   return (
     <AuthProvider>
       <Router>
+        <Navbar />
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/projects" element={<ProjectListPage />} />
-          <Route path="/projects/:id" element={<ProjectDetailPage />} />
+          <Route
+            path="/projects"
+            element={
+              <RequireAuth>
+                <ProjectListPage />
+              </RequireAuth>
+            }
+          />
+          <Route
+            path="/projects/:id"
+            element={
+              <RequireAuth>
+                <ProjectDetailPage />
+              </RequireAuth>
+            }
+          />
         </Routes>
       </Router>
     </AuthProvider>

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,0 +1,5 @@
+// Basic placeholder test to ensure Jest runs
+
+test('dummy test passes', () => {
+  expect(true).toBe(true);
+});

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,2 +1,18 @@
 // Centralized API base URL
+// Uses REACT_APP_API_URL defined at build time
 export const API_BASE_URL = process.env.REACT_APP_API_URL;
+
+/**
+ * Helper around fetch that adds the Authorization header when a token is provided.
+ * @param {string} path Relative API path starting with '/'
+ * @param {object} options Fetch options
+ * @param {string} token JWT token
+ */
+export async function apiFetch(path, options = {}, token) {
+  const headers = options.headers ? { ...options.headers } : {};
+  if (token) {
+    // Include bearer token for authenticated requests
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,26 @@
+import React, { useContext } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+// Simple navigation bar with logout button
+function Navbar() {
+  const navigate = useNavigate();
+  const { token, setAuth } = useContext(AuthContext);
+
+  if (!token) return null;
+
+  const handleLogout = () => {
+    // Clear auth state and redirect to login
+    setAuth({});
+    navigate('/login');
+  };
+
+  return (
+    <nav>
+      <Link to="/projects">Projects</Link>
+      <button onClick={handleLogout}>Logout</button>
+    </nav>
+  );
+}
+
+export default Navbar;

--- a/frontend/src/components/RequireAuth.jsx
+++ b/frontend/src/components/RequireAuth.jsx
@@ -1,0 +1,15 @@
+import React, { useContext } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+
+// Guarded route component: redirects to /login when unauthenticated
+function RequireAuth({ children }) {
+  const { token } = useContext(AuthContext);
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+  // Render children directly or use outlet for nested routes
+  return children ? children : <Outlet />;
+}
+
+export default RequireAuth;

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,11 +1,34 @@
 import React, { createContext, useState } from 'react';
 
+// Authentication context exposes current user, token and setter
 export const AuthContext = createContext(null);
 
 export function AuthProvider({ children }) {
-  const [token, setToken] = useState(null);
+  // Initialize from localStorage to persist login across refreshes
+  const [token, setToken] = useState(() => localStorage.getItem('token'));
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('user');
+    return stored ? JSON.parse(stored) : null;
+  });
+
+  // Helper to update auth state and localStorage
+  const setAuth = ({ token: newToken, user: newUser }) => {
+    if (newToken) {
+      localStorage.setItem('token', newToken);
+    } else {
+      localStorage.removeItem('token');
+    }
+    if (newUser) {
+      localStorage.setItem('user', JSON.stringify(newUser));
+    } else {
+      localStorage.removeItem('user');
+    }
+    setToken(newToken || null);
+    setUser(newUser || null);
+  };
+
   return (
-    <AuthContext.Provider value={{ token, setToken }}>
+    <AuthContext.Provider value={{ user, token, setAuth }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,9 +1,12 @@
 import React, { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { API_BASE_URL } from '../api';
 
+// Login form page
 function LoginPage() {
-  const { setToken } = useContext(AuthContext);
+  const { setAuth } = useContext(AuthContext);
+  const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
@@ -17,7 +20,9 @@ function LoginPage() {
       });
       const data = await res.json();
       if (data.token) {
-        setToken(data.token);
+        // Save token and user then navigate to projects list
+        setAuth({ token: data.token, user: data.user });
+        navigate('/projects');
       }
     } catch (err) {
       console.error(err);

--- a/frontend/src/pages/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetailPage.jsx
@@ -1,12 +1,123 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { apiFetch } from '../api';
 
+// Project detail with tasks, milestones and cost summary
 function ProjectDetailPage() {
   const { id } = useParams();
+  const { token, user } = useContext(AuthContext);
+  const [project, setProject] = useState(null);
+  const [cost, setCost] = useState({ totalHours: 0, totalCost: 0 });
+  const [timeEntry, setTimeEntry] = useState({});
+
+  const loadData = async () => {
+    try {
+      const resProj = await apiFetch(`/projects/${id}`, {}, token);
+      const projData = await resProj.json();
+      setProject(projData);
+      const resCost = await apiFetch(`/projects/${id}/cost`, {}, token);
+      const costData = await resCost.json();
+      setCost(costData);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, [id]);
+
+  const updateStatus = async (taskId, status) => {
+    try {
+      await apiFetch(
+        `/tasks/${taskId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status })
+        },
+        token
+      );
+      loadData();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const logTime = async (taskId) => {
+    try {
+      const entry = timeEntry[taskId] || {};
+      await apiFetch(
+        `/tasks/${taskId}/timelogs`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ hours: entry.hours, date: entry.date })
+        },
+        token
+      );
+      setTimeEntry({ ...timeEntry, [taskId]: { hours: '', date: '' } });
+      loadData();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  if (!project) return <div>Loading...</div>;
+
   return (
     <div>
-      <h1>Project {id}</h1>
-      {/* TODO: show project details, tasks, and time logs */}
+      <h1>{project.name}</h1>
+      <p>
+        Total Hours: {cost.totalHours} | Total Cost: {cost.totalCost}
+      </p>
+
+      <h2>Milestones</h2>
+      <ul>
+        {project.Milestones?.map((m) => (
+          <li key={m.id}>{m.name}</li>
+        ))}
+      </ul>
+
+      <h2>Tasks</h2>
+      <ul>
+        {project.Tasks?.map((t) => (
+          <li key={t.id}>
+            {t.title} - {t.status}
+            {user && user.id === t.assignedUserId && (
+              <div>
+                <button onClick={() => updateStatus(t.id, 'in_progress')}>In Progress</button>
+                <button onClick={() => updateStatus(t.id, 'done')}>Done</button>
+                <div>
+                  <input
+                    type="number"
+                    placeholder="Hours"
+                    value={timeEntry[t.id]?.hours || ''}
+                    onChange={(e) =>
+                      setTimeEntry({
+                        ...timeEntry,
+                        [t.id]: { ...timeEntry[t.id], hours: e.target.value }
+                      })
+                    }
+                  />
+                  <input
+                    type="date"
+                    value={timeEntry[t.id]?.date || ''}
+                    onChange={(e) =>
+                      setTimeEntry({
+                        ...timeEntry,
+                        [t.id]: { ...timeEntry[t.id], date: e.target.value }
+                      })
+                    }
+                  />
+                  <button onClick={() => logTime(t.id)}>Log</button>
+                </div>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/src/pages/ProjectListPage.jsx
+++ b/frontend/src/pages/ProjectListPage.jsx
@@ -1,10 +1,63 @@
-import React from 'react';
+import React, { useEffect, useState, useContext } from 'react';
+import { Link } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { apiFetch } from '../api';
 
+// Page listing projects and allowing admins to create new ones
 function ProjectListPage() {
+  const { token, user } = useContext(AuthContext);
+  const [projects, setProjects] = useState([]);
+  const [name, setName] = useState('');
+
+  const loadProjects = async () => {
+    try {
+      const res = await apiFetch('/projects', {}, token);
+      const data = await res.json();
+      setProjects(data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    loadProjects();
+  }, []);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    try {
+      await apiFetch(
+        '/projects',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name })
+        },
+        token
+      );
+      setName('');
+      loadProjects();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <div>
       <h1>Projects</h1>
-      {/* TODO: fetch and display projects */}
+      <ul>
+        {projects.map((p) => (
+          <li key={p.id}>
+            <Link to={`/projects/${p.id}`}>{p.name}</Link>
+          </li>
+        ))}
+      </ul>
+      {user?.role === 'admin' && (
+        <form onSubmit={handleCreate}>
+          <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Project name" />
+          <button type="submit">Create</button>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- build API helper and AuthContext for token and user state
- protect routes with RequireAuth and add Navbar with logout
- implement login, project list, and project detail pages using backend API
- add npm test script and placeholder Jest test

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4697cac7c83309ae8f3e0f3edc536