### PR TITLE
Add environment config, health endpoint, and frontend logout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ This repository contains a minimal, production-ready scaffold split into two fol
    npm run lint
    ```
 
+### Environment variables
+
+The backend expects the following variables in a `.env` file:
+
+- `DATABASE_URL` – connection string for PostgreSQL
+- `JWT_SECRET` – secret key used to sign JSON Web Tokens
+- `PORT` – port for the HTTP server (defaults to `4000` if not set)
+
 ## Frontend
 
 1. Navigate to the frontend folder:
@@ -50,5 +58,11 @@ This repository contains a minimal, production-ready scaffold split into two fol
    ```bash
    npm run build
    ```
+
+### Environment variables
+
+Create a `.env` file with:
+
+- `REACT_APP_API_URL` – base URL of the backend API (e.g. `http://localhost:4000`)
 
 Both applications use environment variables and are ready for further development.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,4 @@
 # Example environment configuration
 DATABASE_URL=postgres://user:password@localhost:5432/dbname
 JWT_SECRET=your_jwt_secret
-PORT=3000
+PORT=4000

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,6 +17,11 @@ app.use(cors());
 // Parse incoming JSON bodies
 app.use(express.json());
 
+// Simple health check endpoint
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
 // Public auth routes
 app.use('/auth', authRoutes);
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,7 +4,8 @@ const app = require('./app');
 const { sequelize } = require('./config/db');
 const { initModels, syncDb } = require('./models');
 
-const PORT = process.env.PORT || 3000;
+// Use PORT from environment or fall back to 4000
+const PORT = process.env.PORT || 4000;
 
 async function start() {
   try {

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:3000
+REACT_APP_API_URL=http://localhost:4000

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -8,11 +8,16 @@ export const API_BASE_URL = process.env.REACT_APP_API_URL;
  * @param {object} options Fetch options
  * @param {string} token JWT token
  */
-export async function apiFetch(path, options = {}, token) {
+export async function apiFetch(path, options = {}, token, onUnauthorized) {
   const headers = options.headers ? { ...options.headers } : {};
   if (token) {
     // Include bearer token for authenticated requests
     headers['Authorization'] = `Bearer ${token}`;
   }
-  return fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+  const res = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+  if (res.status === 401 && typeof onUnauthorized === 'function') {
+    // If the server reports unauthorized, force logout
+    onUnauthorized();
+  }
+  return res;
 }

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -27,8 +27,11 @@ export function AuthProvider({ children }) {
     setUser(newUser || null);
   };
 
+  // Helper to clear auth state
+  const logout = () => setAuth({});
+
   return (
-    <AuthContext.Provider value={{ user, token, setAuth }}>
+    <AuthContext.Provider value={{ user, token, setAuth, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/ProjectDetailPage.jsx
+++ b/frontend/src/pages/ProjectDetailPage.jsx
@@ -6,17 +6,17 @@ import { apiFetch } from '../api';
 // Project detail with tasks, milestones and cost summary
 function ProjectDetailPage() {
   const { id } = useParams();
-  const { token, user } = useContext(AuthContext);
+  const { token, user, logout } = useContext(AuthContext);
   const [project, setProject] = useState(null);
   const [cost, setCost] = useState({ totalHours: 0, totalCost: 0 });
   const [timeEntry, setTimeEntry] = useState({});
 
   const loadData = async () => {
     try {
-      const resProj = await apiFetch(`/projects/${id}`, {}, token);
+      const resProj = await apiFetch(`/projects/${id}`, {}, token, logout);
       const projData = await resProj.json();
       setProject(projData);
-      const resCost = await apiFetch(`/projects/${id}/cost`, {}, token);
+      const resCost = await apiFetch(`/projects/${id}/cost`, {}, token, logout);
       const costData = await resCost.json();
       setCost(costData);
     } catch (err) {
@@ -37,7 +37,8 @@ function ProjectDetailPage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ status })
         },
-        token
+        token,
+        logout
       );
       loadData();
     } catch (err) {
@@ -55,7 +56,8 @@ function ProjectDetailPage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ hours: entry.hours, date: entry.date })
         },
-        token
+        token,
+        logout
       );
       setTimeEntry({ ...timeEntry, [taskId]: { hours: '', date: '' } });
       loadData();

--- a/frontend/src/pages/ProjectListPage.jsx
+++ b/frontend/src/pages/ProjectListPage.jsx
@@ -5,13 +5,13 @@ import { apiFetch } from '../api';
 
 // Page listing projects and allowing admins to create new ones
 function ProjectListPage() {
-  const { token, user } = useContext(AuthContext);
+  const { token, user, logout } = useContext(AuthContext);
   const [projects, setProjects] = useState([]);
   const [name, setName] = useState('');
 
   const loadProjects = async () => {
     try {
-      const res = await apiFetch('/projects', {}, token);
+      const res = await apiFetch('/projects', {}, token, logout);
       const data = await res.json();
       setProjects(data);
     } catch (err) {
@@ -33,7 +33,8 @@ function ProjectListPage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name })
         },
-        token
+        token,
+        logout
       );
       setName('');
       loadProjects();


### PR DESCRIPTION
## Summary
- Serve a new `/health` endpoint and default backend port to 4000
- Document required environment variables for backend and frontend
- Use `REACT_APP_API_URL` with logout on 401 responses in the frontend

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)
- `DATABASE_URL=postgres://user:pass@localhost:5432/db JWT_SECRET=tmp node - <<'NODE'...`

------
https://chatgpt.com/codex/tasks/task_e_68a46c71a8ac8330b140112db6c57b71