### PR TITLE
feat: add admin promotion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ The backend expects the following variables in a `.env` file:
 - `JWT_SECRET` – secret key used to sign JSON Web Tokens
 - `PORT` – port for the HTTP server (defaults to `4000` if not set)
 
+### Promote a user to admin
+
+Promote an existing account to administrator with a direct SQL query or the helper script.
+
+**SQL (PostgreSQL):**
+
+```sql
+UPDATE "Users" SET role='admin' WHERE email='user@example.com';
+```
+
+**NPM script:**
+
+```bash
+cd backend
+npm run promote:admin -- user@example.com
+```
+
 ## Frontend
 
 1. Navigate to the frontend folder:

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
     "dev": "nodemon src/server.js",
     "start": "node src/server.js",
     "lint": "eslint .",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "promote:admin": "node scripts/promoteAdmin.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.0",

--- a/backend/scripts/promoteAdmin.js
+++ b/backend/scripts/promoteAdmin.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// Promote a user to admin role using their email.
+// Usage: npm run promote:admin -- user@example.com
+require('dotenv').config();
+const { sequelize, User, initModels } = require('../src/models');
+
+(async () => {
+  try {
+    const email = process.argv[2];
+    if (!email) {
+      console.error('Please provide an email.');
+      console.error('Usage: npm run promote:admin -- user@example.com');
+      process.exit(1);
+    }
+
+    // Initialize model associations
+    initModels();
+    await sequelize.authenticate();
+
+    const [updated] = await User.update({ role: 'admin' }, { where: { email } });
+    if (updated === 0) {
+      console.log(`No user found with email ${email}`);
+    } else {
+      console.log(`User ${email} promoted to admin.`);
+    }
+  } catch (err) {
+    console.error('Promotion failed:', err);
+  } finally {
+    await sequelize.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- add script to promote a user to admin by email
- document SQL and usage in README
- expose npm run promote:admin for convenience

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a46e53124c8330b38c8dc2d2bc219e